### PR TITLE
Improve coverage for rare characters

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -8,6 +8,8 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;600&display=swap" rel="stylesheet">
+    <!-- Webfont covering CJK Extension B -->
+    <link rel="stylesheet" href="https://fontlibrary.org//face/babelstone-han" type="text/css"/>
 
     <!-- Favicon 設定 -->
     <link rel="icon" type="image/x-icon" href="favicon.ico">
@@ -44,7 +46,7 @@
         body {
             height: 100vh;
             height: 100dvh;
-            font-family: "Noto Sans TC", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+            font-family: "Noto Sans TC", "BabelStoneHan", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
             background-color: var(--grass-green-bg);
             color: var(--text-color);
             display: flex;


### PR DESCRIPTION
## Summary
- remove README font guidance
- load BabelStone Han webfont for CJK Ext-B fallback

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688a6637c0bc8332bf8fd42ecf621462