### PR TITLE
Add toggling grass mode UI

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -278,6 +278,40 @@
             const copyBtn = document.getElementById('copy-btn');
             const copyFeedback = document.getElementById('copy-feedback');
 
+            const headerTitle = document.querySelector('.app-container > header');
+            const grassBtnLabel = grassBtn.querySelectorAll('span')[1];
+            const degrassBtnLabel = degrassBtn.querySelectorAll('span')[1];
+            const clearBtnLabel = clearBtn.querySelectorAll('span')[1];
+
+            const ORIGINAL_TEXTS = {
+                header: headerTitle.textContent,
+                grass: grassBtnLabel.textContent,
+                degrass: degrassBtnLabel.textContent,
+                clear: clearBtnLabel.textContent,
+            };
+
+            const TRIMMED_TEXTS = {
+                header: '෴ 大草原不可避 ෴',
+                grass: '長草',
+                degrass: '除草',
+                clear: '清除',
+            };
+
+            const GRASSED_TEXTS = {
+                header: '෴ 芖草蒝芣苛避 ෴',
+                grass: '萇草',
+                degrass: '蒢草',
+                clear: '蔳蒢',
+            };
+
+            function applyUiTexts(texts) {
+                const t = texts || TRIMMED_TEXTS;
+                headerTitle.textContent = t.header;
+                grassBtnLabel.textContent = t.grass;
+                degrassBtnLabel.textContent = t.degrass;
+                clearBtnLabel.textContent = t.clear;
+            }
+
             // --- 核心轉換功能 ---
             function toGrassed(text) {
                 let result = '';
@@ -313,6 +347,7 @@
                 if (currentText) {
                     mainText.value = toGrassed(currentText);
                 }
+                applyUiTexts(GRASSED_TEXTS);
                 updateUrl('grassed', mainText.value);
             });
 
@@ -321,12 +356,14 @@
                 if (currentText) {
                     mainText.value = toTrimmed(currentText);
                 }
+                applyUiTexts(TRIMMED_TEXTS);
                 updateUrl('trimmed', mainText.value);
             });
 
             clearBtn.addEventListener('click', () => {
                 mainText.value = '';
                 mainText.focus();
+                applyUiTexts(ORIGINAL_TEXTS);
                 updateUrl();
             });
 
@@ -357,6 +394,14 @@
                 } else if (urlMode === 'trimmed') {
                     mainText.value = toTrimmed(mainText.value);
                 }
+            }
+
+            if (urlMode === 'grassed') {
+                applyUiTexts(GRASSED_TEXTS);
+            } else if (urlMode === 'trimmed') {
+                applyUiTexts(TRIMMED_TEXTS);
+            } else {
+                applyUiTexts(ORIGINAL_TEXTS);
             }
 
             mainText.focus();


### PR DESCRIPTION
## Summary
- toggle header and button text based on the selected mode
- keep original labels from the HTML and restore them when clearing

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688b1f6508948332b86be180d4d36f32