### PR TITLE
Use container query for keyboard layout adjustments

### DIFF
--- a/app/kusa.css
+++ b/app/kusa.css
@@ -19,11 +19,12 @@
 }
 
 html {
-    height: 100%;
+    height: var(--app-vh);
+    container-type: size;
 }
 
 body {
-    height: var(--app-vh);
+    height: 100%;
     font-family: "Noto Sans TC", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
     background-color: var(--grass-green-bg);
     color: var(--text-color);
@@ -31,12 +32,6 @@ body {
     align-items: center;
     justify-content: center;
     padding: 20px;
-}
-
-body.keyboard-open {
-    align-items: flex-start;
-    justify-content: flex-start;
-    padding: 0;
 }
 
 /* --- 主要 App 容器 --- */
@@ -51,6 +46,7 @@ body.keyboard-open {
     display: flex;
     flex-direction: column;
     overflow: hidden;
+    transition: height 0.3s ease, max-height 0.3s ease;
     /* 確保子元素的圓角正確顯示 */
 }
 
@@ -188,9 +184,14 @@ textarea:focus {
     .button-group-right {
         gap: 6px;
     }
-
-    body.keyboard-open .app-container {
-        max-height: none;
-        height: 100%;
+    @container (max-height: 600px) {
+        body {
+            align-items: flex-start;
+            justify-content: flex-start;
+        }
+        .app-container {
+            max-height: none;
+            height: 100%;
+        }
     }
 }

--- a/app/kusa.js
+++ b/app/kusa.js
@@ -104,11 +104,15 @@ class KusaApp {
     updateViewportHeight() {
         const vh = window.visualViewport ? window.visualViewport.height : window.innerHeight;
         document.documentElement.style.setProperty('--app-vh', `${vh}px`);
+    }
 
-        const keyboardThreshold = 150;
-        const isKeyboardOpen = window.innerHeight - vh > keyboardThreshold;
-        const isMobile = window.innerWidth <= 768;
-        document.body.classList.toggle('keyboard-open', isMobile && isKeyboardOpen);
+    destroy() {
+        if (window.visualViewport) {
+            window.visualViewport.removeEventListener('resize', this.boundViewportHandler);
+            window.visualViewport.removeEventListener('scroll', this.boundViewportHandler);
+        } else {
+            window.removeEventListener('resize', this.boundViewportHandler);
+        }
     }
 
     loadFromUrl() {
@@ -164,5 +168,6 @@ class KusaApp {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
-    new KusaApp();
+    const app = new KusaApp();
+    window.addEventListener('beforeunload', () => app.destroy());
 });


### PR DESCRIPTION
## Summary
- replace `keyboard-open` class logic with container queries and smooth height transitions
- clean up viewport listeners on teardown to avoid leaks

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68908b1c85ac8332b62b4fe0a20bc1b4